### PR TITLE
Expanded HasKpi trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,58 @@ Kpi::create([
 ]);
 ```
 
+For convenience, you could use the `HasKpi` trait on your model:
+
+```php
+namespace App\Models;
+
+use Finller\Kpi\HasKpi;
+
+class User extends Model
+{
+    use HasKpi;
+    
+    // ...
+}
+```
+
+If you have historical data, you could also call the `backfillKpiCount` method on your model:
+
+```php
+// Get the number of users for each day
+// from the beginning of your app
+User::backfillKpiCount();
+// Specify a interval, column, start and end dates
+User::backfillKpiCount(
+    interval: KpiInterval::Day, // default
+    column: 'created_at', // default
+    start: now()->subDay(30),
+    end: now(),
+    key: 'count' // default
+);
+// Backfill on callback
+User::backfillKpi(
+    callback: function (Builder $query) {
+        $query->whereBetween($column, [
+            $start,
+            Carbon::parse($date['created_at'])->endOfDay(),
+        ])
+            ->count();
+
+        return [
+            'key' => $key,
+            'number_value' => $count,
+            'created_at' => $date['created_at'],
+        ];
+    },
+    interval: KpiInterval::Day, // default
+    column: 'created_at', // default
+    start: now()->subDay(30),
+    end: now(),
+    key: 'count' // default
+);
+```
+
 Generally kpis are related to models, that's why we provid a trait `HasKpi` with a standardized way to name your kpi key `{namespace}:{key}`. For the User model, it would store your key in the `users` namespace like `users:{key}`.
 
 A standard way to save your kpi values would be in a command that runs every day.

--- a/src/HasKpi.php
+++ b/src/HasKpi.php
@@ -40,59 +40,6 @@ trait HasKpi
         ]);
     }
 
-    /**
-     * @param null|KpiInterval $interval 
-     * @param null|string $column 
-     * @param null|Carbon $start 
-     * @param null|Carbon $end 
-     * @param null|string $key 
-     * @return array 
-     * @throws BindingResolutionException 
-     * @throws NotFoundExceptionInterface 
-     * @throws ContainerExceptionInterface 
-     */
-    public static function backfillKpiCount(
-        ?KpiInterval $interval = KpiInterval::Day,
-        ?string $column = 'created_at',
-        ?Carbon $start = null,
-        ?Carbon $end = null,
-        ?string $key = 'count'
-    ): array {
-        return static::backfillKpi(
-            function ($model, $start, $end, $key, $date) use ($column) {
-                $count = $model->whereBetween($column, [
-                    $start,
-                    Carbon::parse($date['created_at'])->endOfDay(),
-                ])
-                    ->count();
-
-                return [
-                    'key' => $key,
-                    'number_value' => $count,
-                    'created_at' => $date['created_at'],
-                ];
-            },
-            $interval,
-            $column,
-            $start,
-            $end,
-            $key,
-        );
-    }
-
-    /**
-     * @param null|KpiInterval $interval 
-     * @param null|string $column 
-     * @param null|Carbon $start 
-     * @param null|Carbon $end 
-     * @param null|string $key 
-     * @param null|callable $callback 
-     * @return array 
-     * @throws BindingResolutionException 
-     * @throws NotFoundExceptionInterface 
-     * @throws ContainerExceptionInterface 
-     * @throws InvalidFormatException 
-     */
     public static function backfillKpi(
         callable $callback,
         ?KpiInterval $interval = KpiInterval::Day,
@@ -140,5 +87,34 @@ trait HasKpi
         }
         /** @return array */
         return $fillDates;
+    }
+
+    public static function backfillKpiCount(
+        ?KpiInterval $interval = KpiInterval::Day,
+        ?string $column = 'created_at',
+        ?Carbon $start = null,
+        ?Carbon $end = null,
+        ?string $key = 'count'
+    ): array {
+        return static::backfillKpi(
+            function ($model, $start, $end, $key, $date) use ($column) {
+                $count = $model->whereBetween($column, [
+                    $start,
+                    Carbon::parse($date['created_at'])->endOfDay(),
+                ])
+                    ->count();
+
+                return [
+                    'key' => $key,
+                    'number_value' => $count,
+                    'created_at' => $date['created_at'],
+                ];
+            },
+            $interval,
+            $column,
+            $start,
+            $end,
+            $key,
+        );
     }
 }

--- a/src/HasKpi.php
+++ b/src/HasKpi.php
@@ -2,7 +2,19 @@
 
 namespace Finller\Kpi;
 
-use Illuminate\Support\Str;
+use Carbon\{
+    Carbon,
+    Exceptions\InvalidFormatException
+};
+use Illuminate\{
+    Support\Str,
+    Contracts\Container\BindingResolutionException
+};
+use Psr\Container\{
+    NotFoundExceptionInterface,
+    ContainerExceptionInterface
+};
+use Finller\Kpi\Enums\KpiInterval;
 
 trait HasKpi
 {
@@ -23,8 +35,106 @@ trait HasKpi
         $model = config('kpi.kpi_model');
 
         return $model::create([
-            'key' => static::getKpiNamespace().':count',
+            'key' => static::getKpiNamespace() . ':count',
             'number_value' => static::count(),
         ]);
+    }
+
+    /**
+     * @param null|KpiInterval $interval 
+     * @param null|string $column 
+     * @param null|Carbon $start 
+     * @param null|Carbon $end 
+     * @param null|string $key 
+     * @return array 
+     * @throws BindingResolutionException 
+     * @throws NotFoundExceptionInterface 
+     * @throws ContainerExceptionInterface 
+     */
+    public static function backfillKpiCount(
+        ?KpiInterval $interval = KpiInterval::Day,
+        ?string $column = 'created_at',
+        ?Carbon $start = null,
+        ?Carbon $end = null,
+        ?string $key = 'count'
+    ): array {
+        $kpiModel = config('kpi.kpi_model');
+
+        return $kpiModel->backfillKpi(
+            function ($model, $start, $end, $key, $date) use ($column) {
+                return $model->whereBetween($column, [
+                    $start,
+                    Carbon::parse($date['created_at'])->endOfDay(),
+                ])
+                    ->count();
+            },
+            $interval,
+            $column,
+            $start,
+            $end,
+            $key,
+        );
+    }
+
+    /**
+     * @param null|KpiInterval $interval 
+     * @param null|string $column 
+     * @param null|Carbon $start 
+     * @param null|Carbon $end 
+     * @param null|string $key 
+     * @param null|callable $callback 
+     * @return array 
+     * @throws BindingResolutionException 
+     * @throws NotFoundExceptionInterface 
+     * @throws ContainerExceptionInterface 
+     * @throws InvalidFormatException 
+     */
+    public static function backfillKpi(
+        callable $callback,
+        ?KpiInterval $interval = KpiInterval::Day,
+        ?string $column = 'created_at',
+        ?Carbon $start = null,
+        ?Carbon $end = null,
+        ?string $key = 'count',
+    ): array {
+        $kpiModel = config('kpi.kpi_model');
+        /** @var ?Carbon */
+        $start = $start ?? Carbon::parse(static::min($column));
+        /** @var ?Carbon */
+        $end = $end ?? Carbon::parse(static::max($column));
+        /** @var string */
+        $key = static::getKpiNamespace() . ':' . $key;
+        /** @var Carbon[] */
+        $fillDates = $kpiModel::query()
+            ->where('key', $key)
+            ->perInterval($interval)
+            ->between($start, $end)
+            ->get()
+            ->fillGaps($start, $end, $interval, [
+                'key' => $key,
+                'number_value' => 0
+            ])
+            ->toArray();
+
+        foreach ($fillDates as $k => $date) {
+            if (isset($date['id'])) continue;
+
+            $kpi = new $kpiModel();
+
+            $kpi->fill(call_user_func(
+                $callback,
+                static::query(),
+                $start,
+                $end,
+                $key,
+                $date
+            ));
+
+            $kpi->save();
+
+            $fillDates[$k] = $kpi->toArray();
+        }
+        /** @return array */
+        return $fillDates;
     }
 }

--- a/src/HasKpi.php
+++ b/src/HasKpi.php
@@ -58,15 +58,19 @@ trait HasKpi
         ?Carbon $end = null,
         ?string $key = 'count'
     ): array {
-        $kpiModel = config('kpi.kpi_model');
-
-        return $kpiModel->backfillKpi(
+        return static::backfillKpi(
             function ($model, $start, $end, $key, $date) use ($column) {
-                return $model->whereBetween($column, [
+                $count = $model->whereBetween($column, [
                     $start,
                     Carbon::parse($date['created_at'])->endOfDay(),
                 ])
                     ->count();
+
+                return [
+                    'key' => $key,
+                    'number_value' => $count,
+                    'created_at' => $date['created_at'],
+                ];
             },
             $interval,
             $column,

--- a/src/Support/KpiCollection.php
+++ b/src/Support/KpiCollection.php
@@ -2,22 +2,26 @@
 
 namespace Finller\Kpi\Support;
 
-use Carbon\Carbon;
 use Exception;
-use Finller\Kpi\Enums\KpiInterval;
-use Finller\Kpi\Kpi;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Arr;
+use Carbon\Carbon;
+use Finller\Kpi\{
+    Kpi,
+    Enums\KpiInterval
+};
+use Illuminate\{
+    Support\Arr,
+    Database\Eloquent\Collection
+};
 
 class KpiCollection extends Collection
 {
-    public function fillGaps(?Carbon $start = null, ?Carbon $end = null, ?KpiInterval $interval = null, ?array $default = null): static
+    public function fillGaps(?Carbon $start = null, ?Carbon $end = null, ?KpiInterval $interval = null, ?array $default = null, ?callable $callback = null): static
     {
         $model = config('kpi.kpi_model');
 
         $collection = new static($this->sortBy('created_at')->all());  // @phpstan-ignore-line
 
-        if (! $interval && ($this->count() < 2)) {
+        if (!$interval && ($this->count() < 2)) {
             throw new Exception("interval between items can't be guessed from a single element, provid the interval parameter.");
         }
 
@@ -32,7 +36,7 @@ class KpiCollection extends Collection
 
         $interval = $interval ?? $this->guessInterval();
 
-        if (! $start || ! $end || ! $interval) {
+        if (!$start || !$end || !$interval) {
             return $collection;
         }
 
@@ -44,11 +48,17 @@ class KpiCollection extends Collection
             /** @var ?Kpi $item */
             $item = $collection->get($indexItem);
 
-            if (! $item?->created_at->isSameAs($dateFormatComparator, $date)) {
+            if (!$item?->created_at->isSameAs($dateFormatComparator, $date)) {
                 $placeholderItem = $collection->get($indexItem - 1) ?? $item ?? $collection->last();
 
                 $placeholder = new $model();
-                $placeholder->fill(Arr::only($default ?? $placeholderItem?->attributesToArray() ?? [], $placeholder->getFillable()));
+
+                if ($callback !== null) {
+                    $placeholder->fill(call_user_func($callback, $date));
+                } else {
+                    $placeholder->fill(Arr::only($default ?? $placeholderItem?->attributesToArray() ?? [], $placeholder->getFillable()));
+                }
+
                 $placeholder->created_at = $date->clone();
                 $placeholder->updated_at = $date->clone();
 

--- a/src/Support/KpiCollection.php
+++ b/src/Support/KpiCollection.php
@@ -15,8 +15,12 @@ use Illuminate\{
 
 class KpiCollection extends Collection
 {
-    public function fillGaps(?Carbon $start = null, ?Carbon $end = null, ?KpiInterval $interval = null, ?array $default = null, ?callable $callback = null): static
-    {
+    public function fillGaps(
+        ?Carbon $start = null,
+        ?Carbon $end = null,
+        ?KpiInterval $interval = null,
+        ?array $default = null
+    ): static {
         $model = config('kpi.kpi_model');
 
         $collection = new static($this->sortBy('created_at')->all());  // @phpstan-ignore-line
@@ -52,13 +56,7 @@ class KpiCollection extends Collection
                 $placeholderItem = $collection->get($indexItem - 1) ?? $item ?? $collection->last();
 
                 $placeholder = new $model();
-
-                if ($callback !== null) {
-                    $placeholder->fill(call_user_func($callback, $date));
-                } else {
-                    $placeholder->fill(Arr::only($default ?? $placeholderItem?->attributesToArray() ?? [], $placeholder->getFillable()));
-                }
-
+                $placeholder->fill(Arr::only($default ?? $placeholderItem?->attributesToArray() ?? [], $placeholder->getFillable()));
                 $placeholder->created_at = $date->clone();
                 $placeholder->updated_at = $date->clone();
 


### PR DESCRIPTION
### Added
 - `backfillKpi` -> `src/HasKpi.php:43-77`
 - `backfillKpiCount` -> `src/HasKpi.php:79-139`

### Description
When first instantiating KPIs in an already existing project, it could be helpful to gather historical KPI information.

### Usage:
```php
use Carbon\Carbon;
use App\Models\Task; // Add: `use HasKpi`
use Finller\Kpi\Enums\KpiInterval;

Task::backfillKpiCount(
  interval: KpiInterval::Day,
  column: 'created_at',
  start: null,
  end: Carbon::now(),
  key: 'count'
);

Task::backfillKpi(
  function ($model, $start, $end, $key, $date) use ($column) {
    $count = $model->whereBetween($column, [
      $start,
      Carbon::parse($date['created_at'])->endOfDay(),
    ])
      ->count();
    
    return [
      'key' => $key,
      'number_value' => $count,
      'created_at' => $date['created_at']
    ];
  },
  interval: KpiInterval::Day,
  column: 'created_at',
  start: null,
  end: Carbon::now(),
  key: 'count'
);

// These will return an array from Kpi collection
[
  [
    "id" => 1,
    "key" => "tasks:count",
    "number_value" => 1.0,
    "string_value" => null,
    "money_value" => 0,
    "money_currency" => null,
    "json_value" => null,
    "description" => null,
    "metadata" => null,
    "created_at" => "2022-01-13T14:21:28.000000Z",
    "updated_at" => "2023-07-21T22:37:08.000000Z",
  ],
  /// ...
]
```
